### PR TITLE
cli: multi-target scanning and aggregate gating

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,26 +1,18 @@
+# src/cli.py
 import argparse, sys, json
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+
 from src.loader.html_loader import load_from_html
 from src.loader.url_loader import load_from_url
 from src.rules.text_utils import html_to_text
 from src.rules.runner import run_rules
 from src.rules.severity import meets_threshold
-from datetime import datetime, timezone
 
-def main():
-    p = argparse.ArgumentParser(description="Prompt-Injection Scanner CLI")
-    g = p.add_mutually_exclusive_group(required=True)
-    g.add_argument("--html", help="Inline HTML to scan")
-    g.add_argument("--url", help="URL to fetch and scan")
-    p.add_argument("--fail-on", choices=["low", "medium", "high"], help="Fail if findings meet/exceed this severity")
-    args = p.parse_args()
 
-    if args.html:
-        lp = load_from_html(args.html)
-        target = "inline-html"
-    else:
-        lp = load_from_url(args.url)
-        target = args.url
-
+def _scan_one_html(html: str) -> Dict[str, Any]:
+    lp = load_from_html(html)
+    target = "inline-html"
     text = html_to_text(lp.html)
     findings = run_rules(text, html=lp.html)
 
@@ -35,12 +27,85 @@ def main():
         "scanned_at": datetime.now(timezone.utc).isoformat(),
         "target": target,
     }
+    return {"summary": summary, "findings": findings}
 
-    out = {"summary": summary, "findings": findings}
-    print(json.dumps(out, indent=2))
 
-    if meets_threshold(findings, args.fail_on):
-        sys.exit(1)
+def _scan_one_url(url: str) -> Dict[str, Any]:
+    lp = load_from_url(url)
+    target = url
+    text = html_to_text(lp.html)
+    findings = run_rules(text, html=lp.html)
+
+    counts = {"high": 0, "medium": 0, "low": 0}
+    for f in findings:
+        sev = (f.get("severity") or "").lower()
+        if sev in counts:
+            counts[sev] += 1
+
+    summary = {
+        "counts": counts,
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+        "target": target,
+    }
+    return {"summary": summary, "findings": findings}
+
+
+def main():
+    p = argparse.ArgumentParser(description="Prompt-Injection Scanner CLI")
+
+    # Allow multiple occurrences of --html and/or --url
+    p.add_argument("--html", action="append", help="Inline HTML to scan (can be repeated)")
+    p.add_argument("--url", action="append", help="URL to fetch and scan (can be repeated)")
+    p.add_argument("--fail-on", choices=["low", "medium", "high"], help="Fail if any finding meets/exceeds this severity")
+    p.add_argument("--json-only", action="store_true", help="Reserved: print JSON only (default behavior)")
+
+    args = p.parse_args()
+
+    if not args.html and not args.url:
+        p.error("Provide at least one --html or --url")
+
+    results: List[Dict[str, Any]] = []
+
+    if args.html:
+        for h in args.html:
+            results.append(_scan_one_html(h))
+
+    if args.url:
+        for u in args.url:
+            results.append(_scan_one_url(u))
+
+    # If only one target, preserve old output shape for backward compatibility
+    if len(results) == 1:
+        out = results[0]
+        print(json.dumps(out, indent=2))
+        if meets_threshold(out.get("findings", []), args.fail_on):
+            sys.exit(1)
+        sys.exit(0)
+
+    # Multi-target output: aggregate + per-target results
+    aggregate_counts = {"high": 0, "medium": 0, "low": 0}
+    all_findings = []
+    for r in results:
+        c = r["summary"]["counts"]
+        for k in aggregate_counts:
+            aggregate_counts[k] += int(c.get(k, 0))
+        all_findings.extend(r.get("findings", []))
+
+    failed = meets_threshold(all_findings, args.fail_on)
+
+    multi_out = {
+        "aggregate": {
+            "targets": len(results),
+            "counts": aggregate_counts,
+            "failed_threshold": bool(failed),
+            "fail_on": args.fail_on,
+        },
+        "results": results,
+    }
+
+    print(json.dumps(multi_out, indent=2))
+    sys.exit(1 if failed else 0)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_cli_multi.py
+++ b/tests/test_cli_multi.py
@@ -1,0 +1,30 @@
+# tests/test_cli_multi.py
+import subprocess, sys, json
+
+SAFE_HTML = "<div><p>hello world</p></div>"
+RISKY_HTML = "<div><input><div class='ai-output'>AI reply</div></div>"  # HX1 (medium)
+
+def run_cli(args):
+    result = subprocess.run([sys.executable, "-m", "src.cli"] + args, capture_output=True)
+    return result.returncode, result.stdout.decode("utf-8"), result.stderr.decode("utf-8")
+
+def test_cli_multi_targets_aggregates_and_exits_nonzero_on_medium():
+    code, out, err = run_cli(["--html", SAFE_HTML, "--html", RISKY_HTML, "--fail-on", "medium"])
+    assert code == 1, out + err
+    data = json.loads(out)
+    assert "aggregate" in data
+    assert data["aggregate"]["targets"] == 2
+    # HX1 should appear in at least one result
+    assert any(any(f.get("rule_id") == "HX1" for f in r.get("findings", [])) for r in data["results"])
+
+def test_cli_multi_targets_pass_on_high_threshold():
+    code, out, err = run_cli(["--html", SAFE_HTML, "--html", RISKY_HTML, "--fail-on", "high"])
+    assert code == 0, out + err
+    data = json.loads(out)
+    assert data["aggregate"]["failed_threshold"] is False
+
+def test_cli_single_target_back_compat_shape():
+    code, out, err = run_cli(["--html", RISKY_HTML, "--fail-on", "high"])
+    assert code == 0
+    data = json.loads(out)
+    assert "summary" in data and "findings" in data


### PR DESCRIPTION
Allows repeated --html/--url; prints aggregate + per-target results; exits non-zero if any target meets --fail-on.